### PR TITLE
Remove 'test arc' from validate role

### DIFF
--- a/roles/validate/tasks/main.yml
+++ b/roles/validate/tasks/main.yml
@@ -1,14 +1,5 @@
 ---
 # Do some basic sanity checking that things are set up correctly
-- name: Test arc # noqa command-instead-of-shell
-  shell: "arc help --"
-  args:
-    executable: /bin/bash
-  register: result
-  failed_when:
-    - result.rc != 77
-  changed_when: false
-
 - name: Test checkstyle
   shell: "source ~/.sdkman/bin/sdkman-init.sh && ~/.local/bin/checkstyle --version"
   args:


### PR DESCRIPTION
## 📝 Description

We're no longer installing arcanist, so trying to test for successfull arc installation is obviously unnecessary.

## 📋 Checklist

* ⛔ **This PR has not been linted! The --nolint option was used.**
* ⛔ **This PR has not been unit tested! The --notest option was used.**
